### PR TITLE
Get debug output from buildCmd

### DIFF
--- a/diffblue-base.yml
+++ b/diffblue-base.yml
@@ -8,5 +8,5 @@
 # merging a custom yml file on top of this one using the script
 # in dashboard/scripts/update-diffblue-yml. Any options specified here would
 # be overriden to keep consistency with other benchmarks.
-buildCmd: cd librec; mvn compile
+buildCmd: cd librec; mvn -e -X -Dmaven.test.skip=true compile
 testCmd: cd librec; mvn test


### PR DESCRIPTION
The additional output is needed to get the correct classpath on platform.